### PR TITLE
Optimize rendering by using lazy matrix transform updates

### DIFF
--- a/Client/Render/Renderer.hh
+++ b/Client/Render/Renderer.hh
@@ -39,6 +39,7 @@ public:
     uint32_t id = 0;
     float width = 0;
     float height = 0;
+    bool transform_dirty = false;
     Renderer();
     ~Renderer();
 


### PR DESCRIPTION
This optimization targets patterns such as:
```
translate(xyz);
rotate(xyz);
scale(xyz);
...rendering instructions
```
In the current version of the repo, all of these matrix modifications are sent to the js, while this pr would make it only send one matrix modification right before anything is rendered. This makes the overall rendering process faster because there are less bridges between the wasm and js which is a significant portion of the render time.

Potential optimizations for the future can include storing a list of all instructions for the current frame, and once it's finished (frame is over), send the entire list to the js.